### PR TITLE
Ensure the target with the same shape as the input.

### DIFF
--- a/FairBatchSampler.py
+++ b/FairBatchSampler.py
@@ -143,7 +143,9 @@ class FairBatch(Sampler):
         
         self.lb1 = (self.S[1,1])/(self.S[1,1]+(self.S[1,0]))
         self.lb2 = (self.S[-1,1])/(self.S[-1,1]+(self.S[-1,0]))
-    
+        
+        # Ensure the target with the same shape as the input.
+        self.y_data = self.y_data.reshape(-1,1)
     
     def adjust_lambda(self):
         """Adjusts the lambda values for FairBatch algorithm.


### PR DESCRIPTION
BCE loss requires the target with the same shape as the input (line 160), however, the current input (i.e., model predictions) has the shape [batch_size * 1] while the target has the shape [batch_size]. In order to address this problem, we could reshape the target labels to the same shape as the model predictions.